### PR TITLE
Fix atan2 input in sp1_run

### DIFF
--- a/cpp/subproblems/sp.cpp
+++ b/cpp/subproblems/sp.cpp
@@ -183,6 +183,11 @@ namespace IKS {
 							const Eigen::Vector3d& k,
 							double& theta) {
 
+		if ((p1 - p2).norm() < ZERO_THRESH) {
+			theta = 0.0;
+			return false;
+		}
+
 		Eigen::Matrix<double, 3, 1> KxP = k.cross(p1);
 		Eigen::Matrix<double, 3, 2> A;
 		A << KxP, -k.cross(KxP);


### PR DESCRIPTION
If `p1 == p2` in `sp1_run`, `atan2` is passed zero for both x and y. This is undefined and returns an unexpected value of `pi`. This modification checks if `p1 == p2` and returns zero immediately.